### PR TITLE
use $(TargetDir) for TailwindExecutableFolder

### DIFF
--- a/Tailwind.Hosting.Build/Tailwind.Hosting.Build.csproj
+++ b/Tailwind.Hosting.Build/Tailwind.Hosting.Build.csproj
@@ -12,8 +12,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Build.Framework" Version="17.7.2" PrivateAssets="All" />
-		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.7.2" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.Build.Framework" Version="17.14.8" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.8" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tailwind.Hosting.Build/build/Tailwind.Hosting.Build.targets
+++ b/Tailwind.Hosting.Build/build/Tailwind.Hosting.Build.targets
@@ -9,7 +9,7 @@
         <TailwindOutputCssFile Condition="'$(TailwindOutputCssFile)' == ''">wwwroot/app.css</TailwindOutputCssFile>
         <TailwindConfigFile Condition="'$(TailwindConfigFile)' == ''">tailwind.config.js</TailwindConfigFile>
 
-        <_TailwindExecutableFolder>$(MSBuildProjectDirectory)/$(OutputPath)</_TailwindExecutableFolder>
+		<_TailwindExecutableFolder>$(TargetDir)</_TailwindExecutableFolder>
         <_TailwindConfig>$(OutputPath)tailwind.props.json</_TailwindConfig>
     </PropertyGroup>
 

--- a/Tailwind.Hosting.Cli/Tailwind.Hosting.Cli.csproj
+++ b/Tailwind.Hosting.Cli/Tailwind.Hosting.Cli.csproj
@@ -6,6 +6,7 @@
 	</PropertyGroup>
 
   <ItemGroup>
+	  <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" PrivateAssets="All" />
 	  <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Tailwind.Hosting.Cli/Tailwind.Hosting.Cli.csproj
+++ b/Tailwind.Hosting.Cli/Tailwind.Hosting.Cli.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" PrivateAssets="All" />
+	  <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" PrivateAssets="All" />
 	  <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Tailwind.Hosting.Cli/Tailwind.Hosting.Cli.csproj
+++ b/Tailwind.Hosting.Cli/Tailwind.Hosting.Cli.csproj
@@ -6,8 +6,7 @@
 	</PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" PrivateAssets="All" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" PrivateAssets="All" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" PrivateAssets="All" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/Tailwind.Hosting/Tailwind.Hosting.csproj
+++ b/Tailwind.Hosting/Tailwind.Hosting.csproj
@@ -6,9 +6,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" PrivateAssets="All" />
-		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.3.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.7" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tailwind.Hosting/Tailwind.Hosting.csproj
+++ b/Tailwind.Hosting/Tailwind.Hosting.csproj
@@ -8,6 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.3.0" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
 		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.7" PrivateAssets="All" />
 	</ItemGroup>
 


### PR DESCRIPTION
- $(OutputPath) is absolute on Windows when using artifacts-output 
  https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output

Fixes #11 

- [x] @kallebysantos test on Mac before merging